### PR TITLE
Move np to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Magic CSS3 animations",
   "main": "index.js",
   "scripts": {
+    "release": "np",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -24,6 +25,7 @@
     "gulp-postcss": "^9.0.1",
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.0.0",
+    "np": "^7.5.0",
     "postcss": "^8.3.9",
     "sass": "^1.42.1"
   },
@@ -33,8 +35,5 @@
     "animation",
     "animations",
     "magic"
-  ],
-  "dependencies": {
-    "np": "^7.5.0"
-  }
+  ]
 }


### PR DESCRIPTION
This PR moves the np package in package.json from 'dependencies' to 'devDependencies' for the following reasons: 

- It is the recommended installation method as per np docs.
- The current version has moderate level vulnerabilities that unnecessarily appear in dependent packages.